### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ A Node.js implementation of the Model Context Protocol SQLite server, based on t
 
 ## Use with Claude Desktop
 
+### Installing via Smithery
+
+To install MCP SQLite Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-server-sqlite-npx):
+
+```bash
+npx -y @smithery/cli install mcp-server-sqlite-npx --client claude
+```
+
+### Installing Manually
+
 Add the following to `claude_desktop_config.json`:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP SQLite Server
 
+[![smithery badge](https://smithery.ai/badge/mcp-server-sqlite-npx)](https://smithery.ai/server/mcp-server-sqlite-npx)
+
 A Node.js implementation of the Model Context Protocol SQLite server, based on the [official Python reference](https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite). This version provides an npx-based alternative for environments where Python's UVX runner is not available, such as [LibreChat](https://github.com/danny-avila/LibreChat/issues/4876#issuecomment-2561363955).
 
 ## Use with Claude Desktop


### PR DESCRIPTION
This PR makes updates to the README.

1. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-server-sqlite-npx
2. Add installation instructions for using Smithery CLI to install the MCP for Claude Desktop

Let me know if any additional information or adjustments are needed!